### PR TITLE
Eric set default trips

### DIFF
--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -8,18 +8,29 @@ import AddTrip from './AddTrip.jsx'
 import Map from './Map.jsx'
 
 function Main (props) {  
-  //const [allTrips, setAllTrips] = useState([]);
+  const defaultTrip =  {
+    locationName : 'No trips available! Click the Add Trip button to get started.',
+    coordinates : {latitude: 40.7128, longitude: -74.0060},
+    startDate : 'No start date selected',
+    endDate : 'No end date selected',
+    description : 'This is where the description goes.', // in production these could be empty string, values included here for testing
+    default: 'this is the default trip object' // to conditionally render no markers if default
+  }
   const [upcomingTrips, setUpcomingTrips] = useState([]);
   const [pastTrips, setPastTrips] = useState([]);
   const [upcomingOrPast, setUpcomingOrPast] = useState('upcoming');
   const [tripDetailOrAddTrip, setTripDetailOrAddTrip] = useState('tripDetail'); // to conditionally render either TripDetail or AddTrip component
-  const [curSelectedTrip, setCurSelectedTrip] = useState({});
+  const [curSelectedTrip, setCurSelectedTrip] = useState(defaultTrip);
   const [isLoading, setIsLoading] = useState(true);
 
   console.log('curSelectedTrip', curSelectedTrip)
   
   let renderTripDetailOrAddTrip;
   let listToDisplay;
+
+  
+
+
 
   useEffect(() => {
     // GET all trips from DB corresponding to current user
@@ -60,7 +71,9 @@ function Main (props) {
         listToDisplay={listToDisplay} 
         upcomingOrPast={upcomingOrPast}
         setCurSelectedTrip={setCurSelectedTrip} 
-        tripDetailOrAddTrip={tripDetailOrAddTrip} />
+        tripDetailOrAddTrip={tripDetailOrAddTrip} 
+        defaultTrip={defaultTrip}
+        />
       </div>
       {renderTripDetailOrAddTrip}
       <div>

--- a/client/components/Main.jsx
+++ b/client/components/Main.jsx
@@ -14,7 +14,7 @@ function Main (props) {
   const [upcomingOrPast, setUpcomingOrPast] = useState('upcoming');
   const [tripDetailOrAddTrip, setTripDetailOrAddTrip] = useState('tripDetail'); // to conditionally render either TripDetail or AddTrip component
   const [curSelectedTrip, setCurSelectedTrip] = useState({});
-  const [isLoading, setIsloading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
 
   console.log('curSelectedTrip', curSelectedTrip)
   
@@ -26,12 +26,16 @@ function Main (props) {
     fetch("/api/gettrips/6160bc7c7768777ca716ee68")
     .then(res => {return res.json()})
     .then(response => {
-      setUpcomingTrips(response.upcomingTrips);
-      setPastTrips(response.pastTrips);
       // determine default selected trip:
-      const firstUpcomingTrip = response.upcomingTrips[0];
-      setCurSelectedTrip(firstUpcomingTrip);
-      setIsloading(false)
+      if (response.pastTrips) { 
+        setPastTrips(response.pastTrips);
+      }
+      if (response.upcomingTrips) {
+        setUpcomingTrips(response.upcomingTrips);
+        const firstUpcomingTrip = response.upcomingTrips[0];
+        setCurSelectedTrip(firstUpcomingTrip);
+      } 
+      setIsLoading(false);
     });
   }, []);
   
@@ -46,17 +50,17 @@ function Main (props) {
       {isLoading && <div>loading</div>}
       { !isLoading && 
       <>
-      <div>
-        <button type='button' onClick={() => {if(upcomingOrPast === 'past') {setCurSelectedTrip(upcomingTrips[0]); setUpcomingOrPast('upcoming')}; setTripDetailOrAddTrip('tripDetail')}}> See Upcoming Trips</button>
-        <button type='button' onClick={() => {if(upcomingOrPast === 'upcoming') {setCurSelectedTrip(pastTrips[0]); setUpcomingOrPast('past')}; setTripDetailOrAddTrip('tripDetail')}}> See Past Trips</button>
+      <div>                                                   
+        <button type='button' onClick={() => {if(upcomingOrPast === 'past') {setCurSelectedTrip(upcomingTrips[0] ? upcomingTrips[0] : []); setUpcomingOrPast('upcoming')}; setTripDetailOrAddTrip('tripDetail')}}> See Upcoming Trips</button>
+        <button type='button' onClick={() => {if(upcomingOrPast === 'upcoming') {setCurSelectedTrip(pastTrips[0] ? pastTrips[0] : []); setUpcomingOrPast('past')}; setTripDetailOrAddTrip('tripDetail')}}> See Past Trips</button>
         <button type='button' onClick={() => setTripDetailOrAddTrip('addTrip')}> Add A Trip</button>
 
 
       <Map 
-      listToDisplay={listToDisplay} 
-      upcomingOrPast={upcomingOrPast}
-      setCurSelectedTrip={setCurSelectedTrip} 
-      tripDetailOrAddTrip={tripDetailOrAddTrip} />
+        listToDisplay={listToDisplay} 
+        upcomingOrPast={upcomingOrPast}
+        setCurSelectedTrip={setCurSelectedTrip} 
+        tripDetailOrAddTrip={tripDetailOrAddTrip} />
       </div>
       {renderTripDetailOrAddTrip}
       <div>

--- a/client/components/Map.jsx
+++ b/client/components/Map.jsx
@@ -6,42 +6,42 @@ import Geocoder from 'react-map-gl-geocoder'
 import marker from '../images/marker.png';
 
 // Ways to set Mapbox token: https://uber.github.io/react-map-gl/#/Documentation/getting-started/about-mapbox-tokens
-const MAPBOX_TOKEN = '';
+const MAPBOX_TOKEN = 'pk.eyJ1IjoiZWNrc2RlZWVlZSIsImEiOiJja3VoZzU2aWcyZHk5Mm5xamVjYjJmYzBoIn0.jeBXbfS27jfUNY1XikYJ8w';
 
-const Map = ({listToDisplay, tripDetailOrAddTrip, upcomingOrPast, setCurSelectedTrip}) => {
-  const [selected, setSelected] = useState({latitude: null, longitude: null}) // for addTrip mode only
-  const [trips, setTrips] = useState(listToDisplay)
+const Map = ({listToDisplay, tripDetailOrAddTrip, upcomingOrPast, setCurSelectedTrip, defaultTrip}) => {
+  const myTrips = listToDisplay[0] ? listToDisplay : [defaultTrip];
+  const [selected, setSelected] = useState({latitude: null, longitude: null}); // for addTrip mode only
+  const [trips, setTrips] = useState(listToDisplay); // is this necessary? if listToDisplay has changed, then Map will have re-rendered with passed in value of listToDisplay already. so we can just access listToDisplay rather than duplicating it into a local state.
   const [viewport, setViewport] = useState(
     {
-      latitude: listToDisplay[0].coordinates.latitude,
-      longitude: listToDisplay[0].coordinates.longitude,
+      latitude: myTrips[0].coordinates.latitude,
+      longitude: myTrips[0].coordinates.longitude,
       zoom: 1
     }
-  )
+  );
     // {
     //   latitude: 40.7128,
     //   longitude: -74.0060,
     //   zoom: 8
     // });
- useEffect(() => {
-  if (tripDetailOrAddTrip === 'tripDetail') {
-    setViewport({
-      latitude: listToDisplay[0].coordinates.latitude,
-      longitude: listToDisplay[0].coordinates.longitude,
-      zoom: 1
-    });
-  }
-  else {
-    setViewport({
-      latitude: 40.7306,
-      longitude: -73.9866,
-      zoom: 1
-    });
-  }
-setSelected({latitude: null, longitude: null});
-setTrips(listToDisplay)
-}, [tripDetailOrAddTrip, upcomingOrPast]
- )
+  useEffect(() => {
+    if (tripDetailOrAddTrip === 'tripDetail') {
+      setViewport({
+        latitude: myTrips[0].coordinates.latitude,
+        longitude: myTrips[0].coordinates.longitude,
+        zoom: 1
+      });
+    }
+    else {
+      setViewport({
+        latitude: 40.7306,
+        longitude: -73.9866,
+        zoom: 1
+      });
+    }
+    setSelected({latitude: null, longitude: null});
+    setTrips(listToDisplay) // is this necessary? if listToDisplay has changed, then Map will have re-rendered with passed in value of listToDisplay already. so we can just access listToDisplay rather than duplicating it into a local state.
+  }, [tripDetailOrAddTrip, upcomingOrPast]);
 
   const markerClick = (e) => {
     for (let trip of listToDisplay) {
@@ -82,7 +82,7 @@ setTrips(listToDisplay)
 
         {/* TRIP DETAILS MODE */}
         {tripDetailOrAddTrip === 'tripDetail' && 
-
+        // could change 'trips' to listToDisplay:
         trips.map((el, i) => { return (
           <Marker 
             id={el._id}

--- a/client/components/Map.jsx
+++ b/client/components/Map.jsx
@@ -6,12 +6,12 @@ import Geocoder from 'react-map-gl-geocoder'
 import marker from '../images/marker.png';
 
 // Ways to set Mapbox token: https://uber.github.io/react-map-gl/#/Documentation/getting-started/about-mapbox-tokens
-const MAPBOX_TOKEN = '';
+const MAPBOX_TOKEN = 'pk.eyJ1IjoiZWNrc2RlZWVlZSIsImEiOiJja3VoZzU2aWcyZHk5Mm5xamVjYjJmYzBoIn0.jeBXbfS27jfUNY1XikYJ8w';
 
 const Map = ({listToDisplay, tripDetailOrAddTrip, upcomingOrPast, setCurSelectedTrip, defaultTrip}) => {
   const myTrips = listToDisplay[0] ? listToDisplay : [defaultTrip];
   const [selected, setSelected] = useState({latitude: null, longitude: null}); // for addTrip mode only
-  const [trips, setTrips] = useState(listToDisplay); // is this necessary? if listToDisplay has changed, then Map will have re-rendered with passed in value of listToDisplay already. so we can just access listToDisplay rather than duplicating it into a local state.
+  const [trips, setTrips] = useState(listToDisplay);
   const [viewport, setViewport] = useState(
     {
       latitude: myTrips[0].coordinates.latitude,
@@ -40,7 +40,7 @@ const Map = ({listToDisplay, tripDetailOrAddTrip, upcomingOrPast, setCurSelected
       });
     }
     setSelected({latitude: null, longitude: null});
-    setTrips(listToDisplay) // is this necessary? if listToDisplay has changed, then Map will have re-rendered with passed in value of listToDisplay already. so we can just access listToDisplay rather than duplicating it into a local state.
+    setTrips(listToDisplay) 
   }, [tripDetailOrAddTrip, upcomingOrPast]);
 
   const markerClick = (e) => {

--- a/client/components/Map.jsx
+++ b/client/components/Map.jsx
@@ -6,7 +6,7 @@ import Geocoder from 'react-map-gl-geocoder'
 import marker from '../images/marker.png';
 
 // Ways to set Mapbox token: https://uber.github.io/react-map-gl/#/Documentation/getting-started/about-mapbox-tokens
-const MAPBOX_TOKEN = 'pk.eyJ1IjoiZWNrc2RlZWVlZSIsImEiOiJja3VoZzU2aWcyZHk5Mm5xamVjYjJmYzBoIn0.jeBXbfS27jfUNY1XikYJ8w';
+const MAPBOX_TOKEN = '';
 
 const Map = ({listToDisplay, tripDetailOrAddTrip, upcomingOrPast, setCurSelectedTrip, defaultTrip}) => {
   const myTrips = listToDisplay[0] ? listToDisplay : [defaultTrip];

--- a/client/components/Map.jsx
+++ b/client/components/Map.jsx
@@ -9,7 +9,7 @@ import marker from '../images/marker.png';
 const MAPBOX_TOKEN = '';
 
 const Map = ({listToDisplay, tripDetailOrAddTrip, upcomingOrPast, setCurSelectedTrip}) => {
-  const [selected, setSelected] = useState({latitude: null, longitude: null})
+  const [selected, setSelected] = useState({latitude: null, longitude: null}) // for addTrip mode only
   const [trips, setTrips] = useState(listToDisplay)
   const [viewport, setViewport] = useState(
     {
@@ -23,18 +23,21 @@ const Map = ({listToDisplay, tripDetailOrAddTrip, upcomingOrPast, setCurSelected
     //   longitude: -74.0060,
     //   zoom: 8
     // });
- useEffect(() => {if (tripDetailOrAddTrip === 'tripDetail') {setViewport({
-  latitude: listToDisplay[0].coordinates.latitude,
-  longitude: listToDisplay[0].coordinates.longitude,
-  zoom: 1
-});}
-else {
-  setViewport({
-    latitude: 40.7306,
-    longitude: -73.9866,
-    zoom: 1
-  });
-}
+ useEffect(() => {
+  if (tripDetailOrAddTrip === 'tripDetail') {
+    setViewport({
+      latitude: listToDisplay[0].coordinates.latitude,
+      longitude: listToDisplay[0].coordinates.longitude,
+      zoom: 1
+    });
+  }
+  else {
+    setViewport({
+      latitude: 40.7306,
+      longitude: -73.9866,
+      zoom: 1
+    });
+  }
 setSelected({latitude: null, longitude: null});
 setTrips(listToDisplay)
 }, [tripDetailOrAddTrip, upcomingOrPast]

--- a/client/components/TripDetail.jsx
+++ b/client/components/TripDetail.jsx
@@ -8,17 +8,11 @@ function TripDetail({curSelectedTrip}) { // props = current selected trip object
   //const handleSubmission = e => {};
   
   // SELECT DEFAULT VALUES WHEN NO TRIP IS PRESENT
-  const defaultTrip =  {
-    locationName : 'No trips available! Click the Add Trip button to get started.',
-    coordinates : {latitude: 40.7128, longitude: -74.0060},
-    startDate : 'No start date selected',
-    endDate : 'No end date selected',
-    description : 'This is where the description goes.' // in production these could be empty string, values included here for testing
-  }
-  const trip = curSelectedTrip.startDate ? curSelectedTrip : defaultTrip; // check to see if curSelectedTrip isn't empty object
-  const { locationName, coordinates, startDate, endDate, description} = trip;
 
-  
+
+  const { locationName, coordinates, startDate, endDate, description} = curSelectedTrip;
+
+
   return (
     <div className="allEntries"> {/*instead of rendering all entries, make it render only the entry corresponding to currently selected pin on map */}  
       <div className="cell" className='divScroll'>

--- a/client/components/TripDetail.jsx
+++ b/client/components/TripDetail.jsx
@@ -6,10 +6,23 @@ import React, { useState, useEffect } from "react";
 function TripDetail({curSelectedTrip}) { // props = current selected trip object
   // const [tripCoordinates, updateCoordinates] = useState('');
   //const handleSubmission = e => {};
+  
+  // SELECT DEFAULT VALUES WHEN NO TRIP IS PRESENT
+  const defaultTrip =  {
+    locationName : 'No trips available! Click the Add Trip button to get started.',
+    coordinates : {latitude: 40.7128, longitude: -74.0060},
+    startDate : 'No start date selected',
+    endDate : 'No end date selected',
+    description : 'This is where the description goes.' // in production these could be empty string, values included here for testing
+  }
+  const trip = curSelectedTrip.startDate ? curSelectedTrip : defaultTrip; // check to see if curSelectedTrip isn't empty object
+  const { locationName, coordinates, startDate, endDate, description} = trip;
+
+  
   return (
     <div className="allEntries"> {/*instead of rendering all entries, make it render only the entry corresponding to currently selected pin on map */}  
       <div className="cell" className='divScroll'>
-      {curSelectedTrip.locationName} 
+      {locationName} 
       </div>
   </div>
   )


### PR DESCRIPTION
Added default trip object. Altered state in main to conditionally render default trip if no trips are saved in the user's DB. Altered state in TripDetail to do same. 
...
Finished default trip functionality so there should be no errors when a new user visits /Main. Moved default trip object to Main & saved as curSelectedTrip state's default. This way TripDetails can access it without prop drilling. Map needs the deafultTrip object drilled as it has no reference to curSelectedTrip.

THIS BRANCH HAS NOT BEEN TESTED WITH A NEW USER WHO HAS NO TRIPS IN THEIR DB! SHOULD BE TESTED BEFORE MERGING. However, all functionality seems to work with our default user who has trips saved. Despite this, receiving the following errors upon visiting /Main:

<img width="441" alt="Screen Shot 2021-10-11 at 7 00 03 PM" src="https://user-images.githubusercontent.com/83984184/136866120-c83b5620-6cba-43f2-8960-906bd5ffd93e.png">
